### PR TITLE
Unify CMake formatting in freertos-10.2.1 to match repository standards

### DIFF
--- a/lib/main/freertos-arm/freertos-10.2.1/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/CMakeLists.txt
@@ -12,14 +12,19 @@ add_library(freertos EXCLUDE_FROM_ALL
 add_subdirectory(portable)
 
 target_include_directories(freertos
-    PUBLIC include
-    PRIVATE include/freertos
+    PUBLIC
+        include
+    PRIVATE
+        include/freertos
 )
 
 target_link_libraries(freertos
-    PUBLIC freertos-config freertos-portable
+    PUBLIC
+        freertos-config
+        freertos-portable
 )
 
 target_compile_options(freertos
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CA53_64_BIT/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CA53_64_BIT/CMakeLists.txt
@@ -4,14 +4,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CA9/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CA9/CMakeLists.txt
@@ -4,14 +4,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM0/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM0/CMakeLists.txt
@@ -3,14 +3,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM23/non_secure/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM23/non_secure/CMakeLists.txt
@@ -4,14 +4,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM23/secure/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM23/secure/CMakeLists.txt
@@ -6,14 +6,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM23_NTZ/non_secure/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM23_NTZ/non_secure/CMakeLists.txt
@@ -4,14 +4,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM3/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM3/CMakeLists.txt
@@ -3,14 +3,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM33/non_secure/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM33/non_secure/CMakeLists.txt
@@ -4,14 +4,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM33/secure/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM33/secure/CMakeLists.txt
@@ -6,14 +6,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM33_NTZ/non_secure/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM33_NTZ/non_secure/CMakeLists.txt
@@ -4,14 +4,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM3_MPU/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM3_MPU/CMakeLists.txt
@@ -3,14 +3,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM4F/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM4F/CMakeLists.txt
@@ -3,14 +3,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM4_MPU/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM4_MPU/CMakeLists.txt
@@ -3,14 +3,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM7/r0p1/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CM7/r0p1/CMakeLists.txt
@@ -3,14 +3,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CR5/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CR5/CMakeLists.txt
@@ -4,14 +4,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )

--- a/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CRx_No_GIC/CMakeLists.txt
+++ b/lib/main/freertos-arm/freertos-10.2.1/portable/ARM_CRx_No_GIC/CMakeLists.txt
@@ -4,14 +4,18 @@ add_library(freertos-portable EXCLUDE_FROM_ALL
 )
 
 target_include_directories(freertos-portable
-    PUBLIC include/freertos
-    PRIVATE ../../include/freertos
+    PUBLIC
+        include/freertos
+    PRIVATE
+        ../../include/freertos
 )
 
 target_link_libraries(freertos-portable
-    PUBLIC freertos-config
+    PUBLIC
+        freertos-config
 )
 
 target_compile_options(freertos-portable
-    PRIVATE -w
+    PRIVATE
+        -w
 )


### PR DESCRIPTION
Updated CMakeLists.txt files in freertos-10.2.1 to follow the repository's
standard formatting style where PUBLIC, PRIVATE, and INTERFACE keywords
are placed on separate lines with their arguments indented below them.

Changes:
- Main freertos-10.2.1/CMakeLists.txt
- All 16 portable variant CMakeLists.txt files

https://claude.ai/code/session_01JFqXHXK1otw3mbnT2jYJgF